### PR TITLE
DXP v5 support & ibexa-syncvcl cmd

### DIFF
--- a/commands/host/ibexa-syncvcl
+++ b/commands/host/ibexa-syncvcl
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+WRITABLE=$(grep "#ddev-generated" .ddev/varnish/default.vcl)
+if [ "$WRITABLE" == "" ]; then
+    echo "❗️ '#ddev-generated' not found in ddev/varnish/default.vcl -  file is protected "
+    exit    
+fi
+
+PATH_VCL=vendor/ibexa/http-cache/docs/varnish/vcl/varnish6.vcl
+if [ -f $PATH_VCL ]; then
+    ddev exec cp "$PATH_VCL" .ddev/varnish/default.vcl
+    ddev exec sed -i '1s/^/\/\/#ddev-generated\n/' .ddev/varnish/default.vcl
+    ddev exec sed -i 's#/etc/varnish/parameters.vcl#./parameters.vcl#g'  .ddev/varnish/default.vcl
+    echo "✅ Copied vcl from vendor/ibexa/http-cache/docs/"
+fi

--- a/config.varnish.yaml
+++ b/config.varnish.yaml
@@ -1,0 +1,3 @@
+hooks:
+  post-start:
+    - exec-host: ddev ibexa-syncvcl

--- a/install.yaml
+++ b/install.yaml
@@ -5,6 +5,9 @@ project_files:
 - docker-compose.varnish.yaml
 - varnish
 - commands/varnish
+- commands/host
+- config.varnish.yaml
+
 
 pre_install_actions:
     # Make sure we have a ddev version that can support what we do here

--- a/varnish/default.vcl
+++ b/varnish/default.vcl
@@ -1,3 +1,4 @@
+// #ddev-generated
 // Varnish VCL for:
 // - Varnish 6.0 or higher (6.0LTS recommended, and is what we mainly test against)
 //   - Varnish xkey vmod (via varnish-modules package 0.10.2 or higher, or via Varnish Plus)
@@ -9,20 +10,7 @@ vcl 4.1;
 import std;
 import xkey;
 
-backend ezplatform {
-    .host = "web"; //
-    .port = "80";
-}
-
-acl invalidators {
-    "127.0.0.1";
-    "0.0.0.0"/0;
-}
-
-acl debuggers {
-    "127.0.0.1";
-    "0.0.0.0"/0;
-}
+include "./parameters.vcl";
 
 // Called at the beginning of a request, after the complete request has been received
 sub vcl_recv {

--- a/varnish/parameters.vcl
+++ b/varnish/parameters.vcl
@@ -1,0 +1,21 @@
+// #ddev-generated
+// Our Backend - Assuming that web server is listening on port 80
+// Replace the host to fit your setup
+//
+// For additional example see:
+// https://github.com/ezsystems/ezplatform/blob/master/doc/docker/entrypoint/varnish/parameters.vcl
+
+backend ezplatform {
+    .host = "web"; //
+    .port = "80";
+}
+
+acl invalidators {
+    "127.0.0.1";
+    "0.0.0.0"/0;
+}
+
+acl debuggers {
+    "127.0.0.1";
+    "0.0.0.0"/0;
+}


### PR DESCRIPTION
Added command `ddev ibexa-syncvcl`.
- Command copies  `vendor/ibexa/http-cache/docs/varnish/vcl/varnish6.vcl` to `.ddev/varnish/default.vcl`
- New `.ddev/varnish/default.vcl` is write proteced by `#ddev-generated` comment
